### PR TITLE
Change HTTP to HTTPS in Gradle Wrapper distributionUrl

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-all.zip


### PR DESCRIPTION
Fix `HTTP 403` error which occurs during `csv2db` build:
`Exception in thread "main" java.io.IOException: Server returned HTTP response code: 403 for URL: http://services.gradle.org/distributions/gradle-4.0.1-all.zip` 